### PR TITLE
Add Batocera live install location to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ Each folder contains the "fallback" bezel in its root directory, and a bezel for
 
 The exception to this is the default set "default_unglazed". This (hopefully) contains a unique bezel for each system, so no fallback is required. Please try to be conservative about how flashy it is!
 
+In a live Batocera install, these files can be found at `/usr/share/batocera/datainit/decorations/`. You can edit these files to preview your changes.

--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ Each folder contains the "fallback" bezel in its root directory, and a bezel for
 
 The exception to this is the default set "default_unglazed". This (hopefully) contains a unique bezel for each system, so no fallback is required. Please try to be conservative about how flashy it is!
 
-In a live Batocera install, these files can be found at `/usr/share/batocera/datainit/decorations/`. You can edit these files to preview your changes.
+In an installation of Batocera that is currently booted into, these files can be found at `/usr/share/batocera/datainit/decorations/`. You can edit these files to preview your changes.


### PR DESCRIPTION
Adds the location `/usr/share/batocera/datainit/decorations/` to the readme file to better help users that might like to test live edits.